### PR TITLE
docs(readme): note private dev context

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,8 @@ go get -u github.com/Cellularhacker/core-go
 ## ※ Important
 - package name is just `core`. so you have to use like **`core.IsProductionMode()`**, not **`core-go.IsProductionMode()`.**
 
+
+
+## Development Notes
+
+Internal development context (design notes, work log, decisions) for this repo is maintained by the owner in a separate **private** repository — it is **not** required to use this library. Public consumers can ignore.


### PR DESCRIPTION
Adds a short paragraph saying internal dev notes live in a separate private repo. No functional change, no new release needed.