### PR TITLE
ci: self-hosted runner(hoshinova) 전환

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     name: Build check - dev
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, hoshinova, core-go]
     steps:
       - uses: actions/checkout@v4
       - name: Setup go with cache


### PR DESCRIPTION
GitHub Actions 계정 빌링 제약으로 self-hosted runner pool(hoshinova-kr-01/kr-03)로 전환. 워크플로 runs-on을 [self-hosted, hoshinova, core-go] 로 변경.